### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/ethereum/abi.py
+++ b/ethereum/abi.py
@@ -152,19 +152,19 @@ def decint(n):
     if is_numeric(n) and n < 2**256 and n >= -2**255:
         return n
     elif is_numeric(n):
-        raise EncodingError("Number out of range: %r" % n)
+        raise EncodingError("Number out of range: {0!r}".format(n))
     elif is_string(n) and len(n) == 40:
         return big_endian_to_int(decode_hex(n))
     elif is_string(n) and len(n) <= 32:
         return big_endian_to_int(n)
     elif is_string(n) and len(n) > 32:
-        raise EncodingError("String too long: %r" % n)
+        raise EncodingError("String too long: {0!r}".format(n))
     elif n is True:
         return 1
     elif n is False or n is None:
         return 0
     else:
-        raise EncodingError("Cannot encode integer: %r" % n)
+        raise EncodingError("Cannot encode integer: {0!r}".format(n))
 
 
 # Encodes a base datum
@@ -205,7 +205,7 @@ def encode_single(typ, arg):
     # Strings
     elif base == 'string' or base == 'bytes':
         if not is_string(arg):
-            raise EncodingError("Expecting string: %r" % arg)
+            raise EncodingError("Expecting string: {0!r}".format(arg))
         # Fixed length: string<sz>
         if len(sub):
             assert int(sub) <= 32
@@ -219,7 +219,7 @@ def encode_single(typ, arg):
     # Hashes: hash<sz>
     elif base == 'hash':
         if not (int(sub) and int(sub) <= 32):
-            raise EncodingError("too long: %r" % arg)
+            raise EncodingError("too long: {0!r}".format(arg))
         if isnumeric(arg):
             return zpad(encode_int(arg), 32)
         elif len(arg) == int(sub):
@@ -227,7 +227,7 @@ def encode_single(typ, arg):
         elif len(arg) == int(sub) * 2:
             return zpad(decode_hex(arg), 32)
         else:
-            raise EncodingError("Could not parse hash: %r" % arg)
+            raise EncodingError("Could not parse hash: {0!r}".format(arg))
     # Addresses: address (== hash160)
     elif base == 'address':
         assert sub == ''
@@ -240,8 +240,8 @@ def encode_single(typ, arg):
         elif len(arg) == 42 and arg[:2] == '0x':
             return zpad(decode_hex(arg[2:]), 32)
         else:
-            raise EncodingError("Could not parse address: %r" % arg)
-    raise EncodingError("Unhandled type: %r %r" % (base, sub))
+            raise EncodingError("Could not parse address: {0!r}".format(arg))
+    raise EncodingError("Unhandled type: {0!r} {1!r}".format(base, sub))
 
 
 def process_type(typ):
@@ -326,8 +326,7 @@ def enc(typ, arg):
             myhead += enc(lentyp, len(arg))
         else:
             assert len(arg) == arrlist[-1][0], \
-                "Wrong array size: found %d, expecting %d" % \
-                (len(arg), arrlist[-1][0])
+                "Wrong array size: found {0:d}, expecting {1:d}".format(len(arg), arrlist[-1][0])
         for i in range(len(arg)):
             if subsize is None:
                 myhead += enc(lentyp, 32 * len(arg) + len(mytail))

--- a/ethereum/blocks.py
+++ b/ethereum/blocks.py
@@ -299,7 +299,7 @@ class BlockHeader(rlp.Serializable):
         return d
 
     def __repr__(self):
-        return '<%s(#%d %s)>' % (self.__class__.__name__, self.number,
+        return '<{0!s}(#{1:d} {2!s})>'.format(self.__class__.__name__, self.number,
                                  encode_hex(self.hash)[:8])
 
     def __eq__(self, other):
@@ -474,7 +474,7 @@ class Block(rlp.Serializable):
         def must(what, f, symb, a, b):
             if not f(a, b):
                 if dump_block_on_failed_verification:
-                    sys.stderr.write('%r' % self.to_dict())
+                    sys.stderr.write('{0!r}'.format(self.to_dict()))
                 raise VerificationFailed(what, a, symb, b)
 
         def must_equal(what, a, b):
@@ -506,8 +506,7 @@ class Block(rlp.Serializable):
         if not self.check_fields():
             raise ValueError("Block is invalid")
         if len(to_string(self.header.extra_data)) > self.config['MAX_EXTRADATA_LENGTH']:
-            raise ValueError("Extra data cannot exceed %d bytes" \
-                             % default_config['MAX_EXTRADATA_LENGTH'])
+            raise ValueError("Extra data cannot exceed {0:d} bytes".format(default_config['MAX_EXTRADATA_LENGTH']))
         if self.header.coinbase == '':
             raise ValueError("Coinbase cannot be empty address")
         if not self.state.root_hash_valid():
@@ -1119,7 +1118,7 @@ class Block(rlp.Serializable):
         log_state.trace('reverting')
         while len(self.journal) > mysnapshot['journal_size']:
             cache, index, prev, post = self.journal.pop()
-            log_state.trace('%r %r %r %r' % (cache, index, prev, post))
+            log_state.trace('{0!r} {1!r} {2!r} {3!r}'.format(cache, index, prev, post))
             if prev is not None:
                 self.caches[cache][index] = prev
             else:
@@ -1261,7 +1260,7 @@ class Block(rlp.Serializable):
         return self.number < other.number
 
     def __repr__(self):
-        return '<%s(#%d %s)>' % (self.__class__.__name__, self.number, encode_hex(self.hash)[:8])
+        return '<{0!s}(#{1:d} {2!s})>'.format(self.__class__.__name__, self.number, encode_hex(self.hash)[:8])
 
     def __structlog__(self):
         return encode_hex(self.hash)

--- a/ethereum/chain.py
+++ b/ethereum/chain.py
@@ -42,7 +42,7 @@ class Index(object):
 
     # block by number #########
     def _block_by_number_key(self, number):
-        return 'blocknumber:%d' % number
+        return 'blocknumber:{0:d}'.format(number)
 
     def update_blocknumbers(self, blk):
         "start from head and update until the existing indices match the block"

--- a/ethereum/ethash.py
+++ b/ethereum/ethash.py
@@ -54,7 +54,7 @@ def calc_dataset(full_size, cache):
     percent = (full_size // HASH_BYTES) // 100
     for i in range(full_size // HASH_BYTES):
         if i % percent == 0:
-            sys.stderr.write("Completed %d items, %d percent\n" % (i, i // percent))
+            sys.stderr.write("Completed {0:d} items, {1:d} percent\n".format(i, i // percent))
         o.append(calc_dataset_item(cache, i))
     return o
 

--- a/ethereum/ethash_utils.py
+++ b/ethereum/ethash_utils.py
@@ -35,7 +35,7 @@ def decode_int(s):
 
 
 def encode_int(s):
-    a = "%x" % s
+    a = "{0:x}".format(s)
     return b'' if s == 0 else decode_hex('0' * (len(a) % 2) + a)[::-1]
 
 

--- a/ethereum/fastvm.py
+++ b/ethereum/fastvm.py
@@ -75,7 +75,7 @@ class Message(object):
         self.is_create = is_create
 
     def __repr__(self):
-        return '<Message(to:%s...)>' % self.to[:8]
+        return '<Message(to:{0!s}...)>'.format(self.to[:8])
 
 
 class Compustate():

--- a/ethereum/keys.py
+++ b/ethereum/keys.py
@@ -115,14 +115,14 @@ if scrypt is not None:
 def make_keystore_json(priv, pw, kdf="pbkdf2", cipher="aes-128-ctr"):
     # Get the hash function and default parameters
     if kdf not in kdfs:
-        raise Exception("Hash algo %s not supported" % kdf)
+        raise Exception("Hash algo {0!s} not supported".format(kdf))
     kdfeval = kdfs[kdf]["calc"]
     kdfparams = kdfs[kdf]["mkparams"]()
     # Compute derived key
     derivedkey = kdfeval(pw, kdfparams)
     # Get the cipher and default parameters
     if cipher not in ciphers:
-        raise Exception("Encryption algo %s not supported" % cipher)
+        raise Exception("Encryption algo {0!s} not supported".format(cipher))
     encrypt = ciphers[cipher]["encrypt"]
     cipherparams = ciphers[cipher]["mkparams"]()
     # Produce the encryption key and encrypt
@@ -186,13 +186,13 @@ def decode_keystore_json(jsondata, pw):
     kdfparams = cryptdata["kdfparams"]
     kdf = cryptdata["kdf"]
     if cryptdata["kdf"] not in kdfs:
-        raise Exception("Hash algo %s not supported" % kdf)
+        raise Exception("Hash algo {0!s} not supported".format(kdf))
     kdfeval = kdfs[kdf]["calc"]
     # Get cipher and parameters
     cipherparams = cryptdata["cipherparams"]
     cipher = cryptdata["cipher"]
     if cryptdata["cipher"] not in ciphers:
-        raise Exception("Encryption algo %s not supported" % cipher)
+        raise Exception("Encryption algo {0!s} not supported".format(cipher))
     decrypt = ciphers[cipher]["decrypt"]
     # Compute the derived key
     derivedkey = kdfeval(pw, kdfparams)

--- a/ethereum/processblock.py
+++ b/ethereum/processblock.py
@@ -69,14 +69,13 @@ class Log(rlp.Serializable):
         }
 
     def __repr__(self):
-        return '<Log(address=%r, topics=%r, data=%r)>' %  \
-            (encode_hex(self.address), self.topics, self.data)
+        return '<Log(address={0!r}, topics={1!r}, data={2!r})>'.format(encode_hex(self.address), self.topics, self.data)
 
 
 def validate_transaction(block, tx):
 
     def rp(what, actual, target):
-        return '%r: %r actual:%r target:%r' % (tx, what, actual, target)
+        return '{0!r}: {1!r} actual:{2!r} target:{3!r}'.format(tx, what, actual, target)
 
     # (1) The transaction signature is valid;
     if not tx.sender:  # sender is set and validated on Transaction initialization
@@ -114,7 +113,7 @@ def apply_transaction(block, tx):
     # print block.get_nonce(tx.sender), '@@@'
 
     def rp(what, actual, target):
-        return '%r: %r actual:%r target:%r' % (tx, what, actual, target)
+        return '{0!r}: {1!r} actual:{2!r} target:{3!r}'.format(tx, what, actual, target)
 
     intrinsic_gas = tx.intrinsic_gas_used
     if block.number >= block.config['HOMESTEAD_FORK_BLKNUM']:

--- a/ethereum/refcount_db.py
+++ b/ethereum/refcount_db.py
@@ -33,12 +33,12 @@ class RefcountDB(BaseDB):
             new_refcount = utils.encode_int(refcount + 1)
             self.db.put(b'r:'+k, rlp.encode([new_refcount, v]))
             if self.logging:
-                sys.stderr.write('increasing %s %r to: %d\n' % (utils.encode_hex(k), v, refcount + 1))
+                sys.stderr.write('increasing {0!s} {1!r} to: {2:d}\n'.format(utils.encode_hex(k), v, refcount + 1))
         except:
             self.db.put(b'r:'+k, rlp.encode([ONE_ENCODED, v]))
             self.journal.append([ZERO_ENCODED, k])
             if self.logging:
-                sys.stderr.write('increasing %s %r to: %d\n' % (utils.encode_hex(k), v, 1))
+                sys.stderr.write('increasing {0!s} {1!r} to: {2:d}\n'.format(utils.encode_hex(k), v, 1))
 
     put = inc_refcount
 
@@ -48,7 +48,7 @@ class RefcountDB(BaseDB):
         node_object = rlp.decode(self.db.get(b'r:'+k))
         refcount = utils.decode_int(node_object[0])
         if self.logging:
-            sys.stderr.write('decreasing %s to: %d\n' % (utils.encode_hex(k), refcount - 1))
+            sys.stderr.write('decreasing {0!s} to: {1:d}\n'.format(utils.encode_hex(k), refcount - 1))
         assert refcount > 0
         self.journal.append([node_object[0], k])
         new_refcount = utils.encode_int(refcount - 1)
@@ -88,7 +88,7 @@ class RefcountDB(BaseDB):
                     pruned += 1
             except:
                 pass
-        sys.stderr.write('%d nodes successfully pruned\n' % pruned)
+        sys.stderr.write('{0:d} nodes successfully pruned\n'.format(pruned))
         # Delete the deathrow after processing it
         try:
             self.db.delete('deathrow:'+str(epoch))
@@ -114,8 +114,7 @@ class RefcountDB(BaseDB):
                 new_refcount = utils.encode_int(DEATH_ROW_OFFSET + timeout_epoch)
                 self.db.put(b'r:'+nodekey, rlp.encode([new_refcount, val]))
         if len(self.death_row) > 0:
-            sys.stderr.write('%d nodes marked for pruning during block %d\n' %
-                             (len(self.death_row), timeout_epoch))
+            sys.stderr.write('{0:d} nodes marked for pruning during block {1:d}\n'.format(len(self.death_row), timeout_epoch))
         death_row_nodes.extend(self.death_row)
         self.death_row = []
         self.db.put('deathrow:'+str(timeout_epoch),

--- a/ethereum/slogging.py
+++ b/ethereum/slogging.py
@@ -83,7 +83,7 @@ def get_configuration():
         if hasattr(logger, 'level')
     )
 
-    config_string = ','.join('%s:%s' % x for x in name_levels)
+    config_string = ','.join('{0!s}:{1!s}'.format(*x) for x in name_levels)
 
     return dict(config_string=config_string, log_json=root.log_json)
 

--- a/ethereum/tests/profile_vm.py
+++ b/ethereum/tests/profile_vm.py
@@ -12,7 +12,7 @@ logger = get_logger()
 
 
 def do_test_vm(filename, testname=None, testdata=None, limit=99999999, profiler=None):
-    logger.debug('running test:%r in %r' % (testname, filename))
+    logger.debug('running test:{0!r} in {1!r}'.format(testname, filename))
     testutils.run_vm_test(testutils.fixture_to_bytes(testdata), testutils.VERIFY, profiler=profiler)
 
 if __name__ == '__main__':
@@ -33,7 +33,7 @@ if __name__ == '__main__':
                 do_test_vm(filename, testname, testdata, profiler=profiler)
                 seen += str(testname)
                 i += 1
-        print 'ran %d tests' % i
+        print 'ran {0:d} tests'.format(i)
         print 'test key', sha3(seen).encode('hex')
 
     if len(sys.argv) == 1:

--- a/ethereum/tests/stress_test.py
+++ b/ethereum/tests/stress_test.py
@@ -47,7 +47,7 @@ def test_mul():
     t.gas_limit = 100000000
     x = time.time()
     c.exp([i for i in range(81)], 31415)
-    print('Exponentiation done in: %f' % (time.time() - x))
+    print('Exponentiation done in: {0:f}'.format((time.time() - x)))
 
 if __name__ == '__main__':
     test_mul()

--- a/ethereum/tests/test_blocks.py
+++ b/ethereum/tests/test_blocks.py
@@ -95,7 +95,7 @@ def run_block_test(params, config_overrides = {}):
             blockmap[b2.hash] = b2
             env.db.put(b2.hash, rlp.encode(b2))
         if b2:
-            print 'Block %d with state root %s' % (b2.number, b2.state.root_hash.encode('hex'))
+            print 'Block {0:d} with state root {1!s}'.format(b2.number, b2.state.root_hash.encode('hex'))
         # blkdict = b.to_dict(False, True, False, True)
         # assert blk["blockHeader"] == \
         #     translate_keys(blkdict["header"], translator_list, lambda y, x: x, [])
@@ -134,7 +134,7 @@ def main():
         for filename, tests in list(fixtures.items()):
             for testname, testdata in list(tests.items()):
                 if testname == sys.argv[2]:
-                    print("Testing: %s %s" % (filename, testname))
+                    print("Testing: {0!s} {1!s}".format(filename, testname))
                     run_block_test(testdata, {
                         'HOMESTEAD_FORK_BLKNUM': 0 if 'Homestead' in filename else 5 if 'TestNetwork' in filename
                         else 1000000})
@@ -142,7 +142,7 @@ def main():
         for filename, tests in list(fixtures.items()):
             for testname, testdata in list(tests.items()):
                 if (filename.split('/')[-1], testname) not in excludes:
-                    print("Testing: %s %s" % (filename, testname))
+                    print("Testing: {0!s} {1!s}".format(filename, testname))
                     run_block_test(testdata, {
                         'HOMESTEAD_FORK_BLKNUM': 0 if 'Homestead' in filename else 5 if 'TestNetwork' in filename else 1000000})
 

--- a/ethereum/tests/test_bloom.py
+++ b/ethereum/tests/test_bloom.py
@@ -42,7 +42,7 @@ for filename, tests in list(vm_tests_fixtures().items()):
     for testname, testdata in list(tests.items()):
         if 'logs' not in testdata or 'log' not in testname.lower():
             continue
-        func_name = 'test_%s_%s' % (filename, testname)
+        func_name = 'test_{0!s}_{1!s}'.format(filename, testname)
         globals()[func_name] = gen_func(testdata['logs'])
 
 

--- a/ethereum/tests/test_chain.py
+++ b/ethereum/tests/test_chain.py
@@ -301,11 +301,11 @@ def test_block_serialization_with_transaction_other_db():
     a_blk = mkquickgenesis({v: {"balance": utils.denoms.ether * 1}}, db=a_db)
     store_block(a_blk)
     tx = get_transaction()
-    logger.debug('a: state_root before tx %r' % hx(a_blk.state_root))
-    logger.debug('a: state:\n%s' % utils.dump_state(a_blk.state))
+    logger.debug('a: state_root before tx {0!r}'.format(hx(a_blk.state_root)))
+    logger.debug('a: state:\n{0!s}'.format(utils.dump_state(a_blk.state)))
     a_blk2 = mine_next_block(a_blk, transactions=[tx])
-    logger.debug('a: state_root after tx %r' % hx(a_blk2.state_root))
-    logger.debug('a: state:\n%s' % utils.dump_state(a_blk2.state))
+    logger.debug('a: state_root after tx {0!r}'.format(hx(a_blk2.state_root)))
+    logger.debug('a: state:\n{0!s}'.format(utils.dump_state(a_blk2.state)))
     assert tx in a_blk2.get_transactions()
     store_block(a_blk2)
     assert tx in a_blk2.get_transactions()
@@ -316,10 +316,10 @@ def test_block_serialization_with_transaction_other_db():
 
     assert b_blk.number == 0
     assert b_blk == a_blk
-    logger.debug('b: state_root before tx %r' % hx(b_blk.state_root))
+    logger.debug('b: state_root before tx {0!r}'.format(hx(b_blk.state_root)))
     logger.debug('starting deserialization of remote block w/ tx')
     b_blk2 = rlp.decode(rlp.encode(a_blk2), blocks.Block, env=env(b_blk.db))
-    logger.debug('b: state_root after %r' % hx(b_blk2.state_root))
+    logger.debug('b: state_root after {0!r}'.format(hx(b_blk2.state_root)))
 
     assert a_blk2.hash == b_blk2.hash
 

--- a/ethereum/tests/test_contracts.py
+++ b/ethereum/tests/test_contracts.py
@@ -116,10 +116,10 @@ returnten_code = \
     '''
 extern mul2: [double:i]
 
-x = create("%s")
+x = create("{0!s}")
 log(x)
 return(x.double(5))
-''' % filename
+'''.format(filename)
 
 
 def test_returnten():
@@ -146,12 +146,12 @@ filename2 = "inner_qwertyuioplkjhgfdsa.se"
 
 inset_outer_code = \
     '''
-inset("%s")
+inset("{0!s}")
 
 def foo():
     res = self.g(12)
     return res
-''' % filename2
+'''.format(filename2)
 
 
 def test_inset():
@@ -181,8 +181,8 @@ def foo():
     res = self.g(12)
     return res
 
-inset("%s")
-''' % filename25
+inset("{0!s}")
+'''.format(filename25)
 
 
 def test_inset2():
@@ -487,13 +487,13 @@ callcode_test_code = \
     '''
 extern add1: [main:i]
 
-x = create("%s")
+x = create("{0!s}")
 x.main(6)
 x.main(4, call=code)
 x.main(60, call=code)
 x.main(40)
 return(self.storage[1])
-''' % filename3
+'''.format(filename3)
 
 
 def test_callcode():
@@ -1065,11 +1065,11 @@ extern sorter: [sort:a]
 data sorter
 
 def init():
-    self.sorter = create("%s")
+    self.sorter = create("{0!s}")
 
 def test(args:arr):
     return(self.sorter.sort(args, outsz=len(args)):arr)
-''' % filename9
+'''.format(filename9)
 
 
 @pytest.mark.timeout(100)
@@ -1535,9 +1535,9 @@ new_format_outer_test_code = """
 extern blah: [foo:[int256,int256[],bytes]:int256]
 
 def bar():
-    x = create("%s")
+    x = create("{0!s}")
     return x.foo(17, [3, 5, 7], text("dog"))
-""" % filename4
+""".format(filename4)
 
 
 def test_new_format():
@@ -1575,14 +1575,14 @@ extern foo: [get_address:[int256]:address, register:[int256,address]:_]
 data sub
 
 def init():
-    self.sub = create("%s")
+    self.sub = create("{0!s}")
 
 def get_address(key):
     return(self.sub.get_address(key):address)
 
 def register(key, addr:address):
     self.sub.register(key, addr)
-""" % filename5
+""".format(filename5)
 
 
 def test_inner_abi_address_output():

--- a/ethereum/tests/test_keys.py
+++ b/ethereum/tests/test_keys.py
@@ -7,7 +7,7 @@ logger = get_logger()
 
 
 def test_key(filename, testname, testdata,):
-    logger.debug('running test:%r in %r' % (testname, filename))
+    logger.debug('running test:{0!r} in {1!r}'.format(testname, filename))
     assert keys.check_keystore_json(testdata["json"])
     privkey = keys.decode_keystore_json(testdata["json"], testdata["password"])
     assert utils.encode_hex(privkey) == utils.to_string(testdata["priv"])

--- a/ethereum/tests/test_pruning_trie.py
+++ b/ethereum/tests/test_pruning_trie.py
@@ -22,7 +22,7 @@ def check_db_tightness(trees, db):
         for k, v in db.kv.items():
             if rlp.decode(rlp.decode(v)[1]) not in all_nodes:
                 print(utils.encode_hex(k[2:]), rlp.decode(rlp.decode(v)[1]))
-        raise Exception("unpruned key leak: %d %d" % (len(db.kv), len(all_nodes)))
+        raise Exception("unpruned key leak: {0:d} {1:d}".format(len(db.kv), len(all_nodes)))
 
 
 def test_basic_pruning():
@@ -141,7 +141,7 @@ def test_two_trees():
         db.cleanup(i)
         check_db_tightness([t1, t2], db)
     for i in range(NODES):
-        sys.stderr.write('clearing: %d\n' % i)
+        sys.stderr.write('clearing: {0:d}\n'.format(i))
         t1.delete(to_string(NODES - 1 - i))
         db.commit_refcount_changes(NODES + i)
         db.cleanup(NODES + i)
@@ -286,7 +286,7 @@ def test_block_18503_changes():
         c += 1
     print(utils.encode_hex(t1.root_hash))
     for k, v in toadd:
-        sys.stderr.write('kv: %s %s\n' % (k, v))
+        sys.stderr.write('kv: {0!s} {1!s}\n'.format(k, v))
         triekey = utils.sha3(utils.zpad(utils.decode_hex(k[2:]), 32))
         if v == '0x':
             t1.delete(triekey)
@@ -365,7 +365,7 @@ def test_block_18315_changes():
     print(utils.encode_hex(t1.root_hash))
     print(t1.to_dict())
     for k, v in toadd:
-        sys.stderr.write('kv: %s %s\n' % (k, v))
+        sys.stderr.write('kv: {0!s} {1!s}\n'.format(k, v))
         triekey = utils.sha3(utils.zpad(utils.decode_hex(k[2:]), 32))
         if v == '0x':
             t1.delete(triekey)

--- a/ethereum/tests/test_remoteblocks.py
+++ b/ethereum/tests/test_remoteblocks.py
@@ -16,8 +16,7 @@ def import_chain_data(raw_blocks_fn, test_db_path, skip=0):
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
-        print("usage:%s <raw_blocks_fn> <db_path> <skip?> <formt?>"
-              % sys.argv[0])
+        print("usage:{0!s} <raw_blocks_fn> <db_path> <skip?> <formt?>".format(sys.argv[0]))
         sys.exit(1)
     raw_blocks_fn = sys.argv[1]
     test_db_path = sys.argv[2]

--- a/ethereum/tests/test_serialization.py
+++ b/ethereum/tests/test_serialization.py
@@ -14,9 +14,9 @@ returnten_code = \
     '''
 extern mul2: [double:i]
 
-x = create("%s")
+x = create("{0!s}")
 return(x.double(5))
-''' % filename
+'''.format(filename)
 
 
 def test_returnten():

--- a/ethereum/tests/test_state.py
+++ b/ethereum/tests/test_state.py
@@ -12,7 +12,7 @@ if '--trace' in sys.argv:  # not default
 
 
 def test_state(filename, testname, testdata):
-    logger.debug('running test:%r in %r' % (testname, filename))
+    logger.debug('running test:{0!r} in {1!r}'.format(testname, filename))
     testutils.check_state_test(testutils.fixture_to_bytes(testdata))
 
 
@@ -42,7 +42,7 @@ def main():
     for filename, tests in list(fixtures.items()):
         for testname, testdata in list(tests.items()):
             if len(sys.argv) < 3 or testname == sys.argv[2]:
-                print("Testing: %s %s" % (filename, testname))
+                print("Testing: {0!s} {1!s}".format(filename, testname))
                 testutils.check_state_test(testdata)
 
 

--- a/ethereum/tests/test_transactions.py
+++ b/ethereum/tests/test_transactions.py
@@ -64,7 +64,7 @@ def main():
     for filename, tests in list(fixtures.items()):
         for testname, testdata in list(tests.items()):
             if len(sys.argv) < 3 or testname == sys.argv[2]:
-                print("Testing: %s %s" % (filename, testname))
+                print("Testing: {0!s} {1!s}".format(filename, testname))
                 # testutils.check_state_test(testdata)
                 test_transaction(filename, testname, testdata)
 

--- a/ethereum/tests/test_trie.py
+++ b/ethereum/tests/test_trie.py
@@ -36,7 +36,7 @@ def load_tests():
 
 def run_test(name, pairs):
 
-    logger.debug('testing %s' % name)
+    logger.debug('testing {0!s}'.format(name))
 
     def _dec(x):
         if is_string(x) and x.startswith(b'0x'):
@@ -61,7 +61,7 @@ def run_test(name, pairs):
         for k, v in deletes:
             t.delete(k)
         if pairs['root'] != b'0x' + encode_hex(t.root_hash):
-            raise Exception("Mismatch: %r %r %r %r" % (
+            raise Exception("Mismatch: {0!r} {1!r} {2!r} {3!r}".format(
                 name, pairs['root'], b'0x' + encode_hex(t.root_hash), (i, list(permut) + deletes)))
 
 

--- a/ethereum/tests/test_trie_next_prev.py
+++ b/ethereum/tests/test_trie_next_prev.py
@@ -28,12 +28,12 @@ def load_tests():
 
 def run_test(name):
 
-    logger.debug('testing %s' % name)
+    logger.debug('testing {0!s}'.format(name))
     t = trie.Trie(new_db())
     data = load_tests()[name]
 
     for k in data['in']:
-        logger.debug('updating with (%s, %s)' % (k, k))
+        logger.debug('updating with ({0!s}, {1!s})'.format(k, k))
         k = to_string(k)
         t.update(k, k)
     for point, prev, nxt in data['tests']:

--- a/ethereum/tests/test_vm.py
+++ b/ethereum/tests/test_vm.py
@@ -31,7 +31,7 @@ def main():
     for filename, tests in list(fixtures.items()):
         for testname, testdata in list(tests.items()):
             if len(sys.argv) < 3 or testname == sys.argv[2]:
-                print("Testing: %s %s" % (filename, testname))
+                print("Testing: {0!s} {1!s}".format(filename, testname))
                 testutils.check_vm_test(testdata)
 
 

--- a/ethereum/tests/test_vm_failing.py
+++ b/ethereum/tests/test_vm_failing.py
@@ -7,7 +7,7 @@ logger = get_logger()
 
 
 def do_test_vm(filename, testname=None, testdata=None, limit=99999999):
-    logger.debug('running test:%r in %r' % (testname, filename))
+    logger.debug('running test:{0!r} in {1!r}'.format(testname, filename))
     testutils.check_vm_test(testutils.fixture_to_bytes(testdata))
 
 
@@ -37,7 +37,7 @@ def mk_test_func(filename, testname, testdata):
 collected = []
 for filename, tests in list(fixtures.items()):
     for testname, testdata in list(tests.items()):
-        func_name = 'test_%s_%s' % (filename, testname)
+        func_name = 'test_{0!s}_{1!s}'.format(filename, testname)
         if testname not in failing:
             continue
         collected.append((func_name, filename, testname, testdata))

--- a/ethereum/testutils.py
+++ b/ethereum/testutils.py
@@ -75,7 +75,7 @@ def compare_post_states(shouldbe, reallyis):
     if shouldbe is None and reallyis is None:
         return True
     if shouldbe is None or reallyis is None:
-        raise Exception("Shouldbe: %r \n\nreallyis: %r" % (shouldbe, reallyis))
+        raise Exception("Shouldbe: {0!r} \n\nreallyis: {1!r}".format(shouldbe, reallyis))
     for k in shouldbe:
         if k not in reallyis:
             r = {"nonce": 0, "balance": 0, "code": b"0x", "storage": {}}
@@ -83,8 +83,7 @@ def compare_post_states(shouldbe, reallyis):
             r = acct_standard_form(reallyis[k])
         s = acct_standard_form(shouldbe[k])
         if s != r:
-            raise Exception("Key %r\n\nshouldbe: %r \n\nreallyis: %r" %
-                            (k, s, r))
+            raise Exception("Key {0!r}\n\nshouldbe: {1!r} \n\nreallyis: {2!r}".format(k, s, r))
     return True
 
 
@@ -268,8 +267,7 @@ def run_vm_test(params, mode, profiler=None):
             shouldbe = normalize_value(k, params1)
             reallyis = normalize_value(k, params2)
             if shouldbe != reallyis:
-                raise Exception("Mismatch: " + k + ':\n shouldbe %r\n reallyis %r' %
-                                (shouldbe, reallyis))
+                raise Exception("Mismatch: " + k + ':\n shouldbe {0!r}\n reallyis {1!r}'.format(shouldbe, reallyis))
     elif mode == TIME:
         return time_post - time_pre
 
@@ -392,8 +390,7 @@ def run_state_test(params, mode):
             shouldbe = params1.get(k, None)
             reallyis = params2.get(k, None)
             if shouldbe != reallyis:
-                raise Exception("Mismatch: " + k + ':\n shouldbe %r\n reallyis %r' %
-                                (shouldbe, reallyis))
+                raise Exception("Mismatch: " + k + ':\n shouldbe {0!r}\n reallyis {1!r}'.format(shouldbe, reallyis))
 
     elif mode == TIME:
         return time_post - time_pre
@@ -443,9 +440,9 @@ def run_ethash_test(params, mode):
         return params
     elif mode == VERIFY:
         should, actual = header.mixhash, light_verify['mixhash']
-        assert should == actual, "Mismatch: mixhash %r %r" % (should, actual)
+        assert should == actual, "Mismatch: mixhash {0!r} {1!r}".format(should, actual)
         for k, v in list(out.items()):
-            assert params[k] == v, "Mismatch: " + k + ' %r %r' % (params[k], v)
+            assert params[k] == v, "Mismatch: " + k + ' {0!r} {1!r}'.format(params[k], v)
     elif mode == TIME:
         return {
             "cache_gen": t2 - t1,

--- a/ethereum/transactions.py
+++ b/ethereum/transactions.py
@@ -184,7 +184,7 @@ class Transaction(rlp.Serializable):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return '<Transaction(%s)>' % encode_hex(self.hash)[:4]
+        return '<Transaction({0!s})>'.format(encode_hex(self.hash)[:4])
 
     def __structlog__(self):
         return encode_hex(self.hash)

--- a/ethereum/utils.py
+++ b/ethereum/utils.py
@@ -146,7 +146,7 @@ def normalize_address(x, allow_blank=False):
         assert len(x) == 24 and sha3(x[:20])[:4] == x[-4:]
         x = x[:20]
     if len(x) != 20:
-        raise Exception("Invalid address format: %r" % x)
+        raise Exception("Invalid address format: {0!r}".format(x))
     return x
 
 
@@ -269,7 +269,7 @@ def encode_root(v):
 def encode_int(v):
     '''encodes an integer into serialization'''
     if not is_numeric(v) or v < 0 or v >= TT256:
-        raise Exception("Integer invalid or out of range: %r" % v)
+        raise Exception("Integer invalid or out of range: {0!r}".format(v))
     return int_to_big_endian(v)
 
 
@@ -390,7 +390,7 @@ def print_func_call(ignore_first_arg=False, max_call_number=100):
 def dump_state(trie):
     res = ''
     for k, v in list(trie.to_dict().items()):
-        res += '%r:%r\n' % (encode_hex(k), encode_hex(v))
+        res += '{0!r}:{1!r}\n'.format(encode_hex(k), encode_hex(v))
     return res
 
 

--- a/ethereum/vm.py
+++ b/ethereum/vm.py
@@ -69,7 +69,7 @@ class Message(object):
         self.transfers_value = transfers_value
 
     def __repr__(self):
-        return '<Message(to:%s...)>' % self.to[:8]
+        return '<Message(to:{0!s}...)>'.format(self.to[:8])
 
 
 class Compustate():


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pyethereum?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pyethereum?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
